### PR TITLE
Ox fixen

### DIFF
--- a/contrib/lisp/ox-org.el
+++ b/contrib/lisp/ox-org.el
@@ -560,8 +560,7 @@ point beyond the end of the while timestamp."
 		(insert (make-string (1+ depth) ? )))
 	    (insert ":END:\n"))))))
 
-    (outline-back-to-heading)
-    (org-set-tags t)))
+    (outline-back-to-heading)))
 
 ;;; Org utility functions:
 

--- a/contrib/lisp/ox-org.el
+++ b/contrib/lisp/ox-org.el
@@ -71,7 +71,7 @@
 
 (defun org-x-org-group-identifiers ()
   (save-excursion
-    (outline-up-heading 1)
+    (org-up-heading-safe)
     (outline-next-heading)
     (let* ((depth (org-x--heading-depth))
 	   (current-depth depth)
@@ -396,13 +396,16 @@ point beyond the end of the while timestamp."
 	  (save-restriction
 	    (save-excursion
 	      (widen)
-	      (ignore-errors
-		(dotimes (i 20)
-		  (outline-up-heading 1)
-		  (mapc (lambda (prop)
-			  (org-x-set-parent-property entry (car prop)
+	      (outline-back-to-heading)
+	      (let (level (prev-level (org-outline-level)))
+		(while (progn (org-up-heading-safe)
+			      (and (outline-on-heading-p)
+				   (< (setq level (org-outline-level)) prev-level)))
+		  (setq prev-level level)
+		    (mapc (lambda (prop)
+			    (org-x-set-parent-property entry (car prop)
 						     (cdr prop)))
-			(org-entry-properties)))))))))
+			  (org-entry-properties)))))))))
     entry))
 
 ;;; Org writer:

--- a/contrib/lisp/ox.el
+++ b/contrib/lisp/ox.el
@@ -597,8 +597,8 @@ the majority of dispatch API functions.")
   value)
 
 (defun org-x-remove-property (entry name &optional propagate)
-  (let* ((properties (assq 'properties entry))
-	 (cell (assoc name (cdr properties))))
+  (let* ((properties (assoc 'properties entry))
+         (cell (assoc name (cdr properties))))
     (if cell
 	(setcdr properties (delq cell (cdr properties)))))
   (if propagate


### PR DESCRIPTION
Various fixes here:
- you missed an `assq`
- speedups and fixes for org-x-parse-entry.  It was putting bogus parent-property data in entries with no parent
- tag realign message suppression (which I need for my winnowing)

I guess that last one shouldn't be in this request.  So sue me.
