### PR TITLE
make org-at-heading-p return non-nil only in org-mode

### DIFF
--- a/lisp/org.el
+++ b/lisp/org.el
@@ -23099,7 +23099,8 @@ This version does not only check the character property, but also
     (null (re-search-backward org-outline-regexp-bol nil t))))
 
 (defun org-at-heading-p (&optional ignored)
-  (outline-on-heading-p t))
+  (and (derived-mode-p 'org-mode)
+       (outline-on-heading-p t)))
 ;; Compatibility alias with Org versions < 7.8.03
 (defalias 'org-on-heading-p 'org-at-heading-p)
 


### PR DESCRIPTION
This produces unpleasant conflicts with evil keybindings when 
https://github.com/GuiltyDolphin/org-evil/blob/master/org-evil-commands.el#L33.